### PR TITLE
Fix: gt zero diff

### DIFF
--- a/plugins/aggregators/basicstats/basicstats.go
+++ b/plugins/aggregators/basicstats/basicstats.go
@@ -27,6 +27,7 @@ type configuredStats struct {
 	diff              bool
 	non_negative_diff bool
 	start_time        bool
+	gt_zero_diff      bool
 }
 
 func NewBasicStats() *BasicStats {
@@ -189,6 +190,9 @@ func (b *BasicStats) Push(acc telegraf.Accumulator) {
 				if b.statsConfig.non_negative_diff && v.diff >= 0 {
 					fields[k+"_non_negative_diff"] = v.diff
 				}
+				if b.statsConfig.gt_zero_diff && v.diff > 0 {
+					fields[k+"_gt_zero_diff"] = v.diff
+				}
 
 			}
 			//if count == 1 StdDev = infinite => so I won't send data
@@ -224,6 +228,8 @@ func (b *BasicStats) parseStats() *configuredStats {
 			parsed.diff = true
 		case "non_negative_diff":
 			parsed.non_negative_diff = true
+		case "gt_zero_diff":
+			parsed.gt_zero_diff = true
 		case "start_time":
 			parsed.start_time = true
 

--- a/plugins/aggregators/basicstats/basicstats_test.go
+++ b/plugins/aggregators/basicstats/basicstats_test.go
@@ -496,6 +496,29 @@ func TestBasicStatsWithDiff(t *testing.T) {
 	}
 	acc.AssertContainsTaggedFields(t, "m1", expectedFields, expectedTags)
 }
+func TestBasicStatsWithGtZeroDiff(t *testing.T) {
+
+	aggregator := NewBasicStats()
+	aggregator.Stats = []string{"gt_zero_diff"}
+	aggregator.Log = testutil.Logger{}
+	aggregator.getConfiguredStats()
+
+	aggregator.Add(m1)
+	aggregator.Add(m2)
+
+	acc := testutil.Accumulator{}
+	aggregator.Push(&acc)
+
+	expectedFields := map[string]interface{}{
+		"b_gt_zero_diff": float64(2),
+		"c_gt_zero_diff": float64(2),
+		"d_gt_zero_diff": float64(4),
+	}
+	expectedTags := map[string]string{
+		"foo": "bar",
+	}
+	acc.AssertContainsTaggedFields(t, "m1", expectedFields, expectedTags)
+}
 
 // Test only aggregating non_negative_diff
 func TestBasicStatsWithNonNegativeDiff(t *testing.T) {

--- a/plugins/aggregators/basicstats/basicstats_test.go
+++ b/plugins/aggregators/basicstats/basicstats_test.go
@@ -496,6 +496,8 @@ func TestBasicStatsWithDiff(t *testing.T) {
 	}
 	acc.AssertContainsTaggedFields(t, "m1", expectedFields, expectedTags)
 }
+
+// Test only aggregating greater than zero diff
 func TestBasicStatsWithGtZeroDiff(t *testing.T) {
 
 	aggregator := NewBasicStats()


### PR DESCRIPTION
### Required for all PRs:

Related to [ME-1510](https://multiplay.atlassian.net/browse/ME-1510)

Diffs should not include negative or zero values. 